### PR TITLE
Updating regex for compatibility problems

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -260,7 +260,7 @@ error_wall() {
 }
 
 # Validate the log; fail if we find compatibility problems.
-if (grep -E -q "^Plugin (.*) against .*: .* compatibility problems?$" "$VERIFICATION_OUTPUT_LOG"); then
+if (grep -E -q "^Plugin (.*) against .*: .* compatibility problems?" "$VERIFICATION_OUTPUT_LOG"); then
   error_wall
 elif egrep -q "^The following files specified for the verification are not valid plugins:$" "$VERIFICATION_OUTPUT_LOG"; then
   error_wall


### PR DESCRIPTION
Progress towards https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/issues/11

- Removes the `$`, which indicates the end of a line, from the "compatibility problems" regex
- The plugin verifier appends warning statements after the "compatibility problems" text output, meaning the regex would previously miss throwing errors if a plugin had both compatibility problems and warnings