### PR TITLE
Duplicate IDE detection & zip file validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN apk --no-cache add jq
 # We need curl to download the verifier jar
 RUN apk --no-cache add curl
 
+# We need zip to test the downloaded IDEs
+RUN apk --no-cache add zip
+
 # Copies your code file from the repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,20 @@ if [[ -f "$GITHUB_WORKSPACE/$INPUT_IDE_VERSIONS" ]]; then
   done
 fi
 
+# Check if there are duplicate entries in the list of IDE_VERSIONS, if so, error out and show the user a clear message
+detect=$(printf '%s\n' "${INPUT_IDE_VERSIONS[@]}"|awk '!($0 in seen){seen[$0];next} 1')
+if [[ ${#detect} -gt 8 ]] ; then
+    echo "::error::Duplicate ide-versions found:"
+    echo "$detect" | while read -r INPUT_IDE_VERSION; do
+      echo "::error::        => $INPUT_IDE_VERSION"
+    done
+    echo "::error::"
+    echo "::error::Please remove the duplicate entries before proceeding."
+    exit 1 # An error has occurred - duplicate ide-version entries found.
+else
+    gh_debug "No duplicate IDE_VERSIONS found, proceeding..."
+fi
+
 ##
 # Resolve verifier values
 ##

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -200,32 +200,64 @@ echo "$INPUT_IDE_VERSIONS" | while read -r IDE_VERSION; do
 
   ZIP_FILE_PATH="$HOME/$IDE-$VERSION.zip"
 
-  echo "Downloading [$DOWNLOAD_URL] into [$ZIP_FILE_PATH]..."
-  curl -L --output "$ZIP_FILE_PATH" "$DOWNLOAD_URL"
+  echo "Downloading $IDE $IDE_VERSION from [$DOWNLOAD_URL] into [$ZIP_FILE_PATH]..."
+  CURL_RESP=$(curl -L --silent --show-error -w 'HTTP/%{http_code} - content-type: %{content_type}' --output "$ZIP_FILE_PATH" "$DOWNLOAD_URL")
+
+  gh_debug_disk_space
+
+  gh_debug "Checking response code and content type for the download of [$DOWNLOAD_URL] to ensure download successful..."
+  # Turn off 'exit on error'; if we error out when testing the response code,
+  # we want to first print a friendly message to the user and then exit.
+  set +o errexit
+  echo "$CURL_RESP" | grep "HTTP/200 - content-type: application/octet-stream"
+  if [[ $? -eq 0 ]]; then
+    gh_debug "Download of [$DOWNLOAD_URL] to [$ZIP_FILE_PATH] was successful."
+  else
+    read -r -d '' message <<EOF
+::error::=======================================================================================
+::error::It appears the download of $DOWNLOAD_URL did not contain the following:
+::error::    - status: 200
+::error::    - content-type: application/octet-stream
+::error::
+::error::Actual response: $CURL_RESP
+::error::
+::error::This can happen if $IDE_VERSION is not a valid IDE / version. If you believe it is a
+::error::valid ide/version, please open an issue on GitHub:
+::error::     https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/issues/new
+::error::
+::error::As a precaution, we are failing this execution.
+::error::=======================================================================================
+EOF
+    # Print the message
+    echo "$message"
+    exit 1 # An error has occurred - invalid download headers.
+  fi
+  # Restore 'exit on error', as the test is over.
+  set -o errexit
 
   gh_debug "Testing [$ZIP_FILE_PATH] to ensure it is a valid zip file..."
-  # Turn off 'exit on error', as if we error out when testing the zip we want
-  # to print a friendly message to the user and skip this version and proceed.
+  # Turn off 'exit on error'; if we error out when testing the zip file,
+  # we want to first print a friendly message to the user and then exit.
   set +o errexit
   zip -T "$ZIP_FILE_PATH"
   if [[ $? -eq 0 ]]; then
     gh_debug "[$ZIP_FILE_PATH] appears to be a valid zip file. Proceeding..."
   else
-    message=$(cat <<EOF
-::warning::=======================================================================================
-::warning::It appears $ZIP_FILE_PATH is not a valid zip file.
-::warning::
-::warning::This can happen when the download did not work properly, or if $IDE_VERSION is
-::warning::not a valid IDE / version. If you believe it is a valid version, please open
-::warning::an issue on GitHub:
-::warning::     https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/issues/new
-::warning::
-::warning::For the time being, this IDE / Version is being skipped.
-::warning::=======================================================================================
-EOF)
+    read -r -d '' message <<EOF
+::error::=======================================================================================
+::error::It appears $ZIP_FILE_PATH is not a valid zip file.
+::error::
+::error::This can happen when the download did not work properly, or if $IDE_VERSION is
+::error::not a valid IDE / version. If you believe it is a valid version, please open
+::error::an issue on GitHub:
+::error::     https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/issues/new
+::error::
+::error::For the time being, this IDE / Version is being skipped.
+::error::=======================================================================================
+EOF
     # Print the message
     echo "$message"
-    continue
+    exit 1 # An error has occurred - invalid zip file.
   fi
   # Restore 'exit on error', as the test is over.
   set -o errexit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -252,7 +252,7 @@ EOF
 ::error::an issue on GitHub:
 ::error::     https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/issues/new
 ::error::
-::error::For the time being, this IDE / Version is being skipped.
+::error::As a precaution, we are failing this execution.
 ::error::=======================================================================================
 EOF
     # Print the message


### PR DESCRIPTION
# This PR adds
1. **Duplicate IDE detection** - if two of the same `IDE:Version` combinations are specified the GH action will attempt to extract the zip file twice and error out. This change will cause the GitHub action to detect duplicate entries and instead error out with a more clear message directing the user to remove one of the duplicates. This was chosen instead of just de-dup and proceeding, as both @filiphr and myself feel it could lead to a false sense of security from users (see https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/issues/9#issuecomment-721082985 for details).
2. **Zip file validation** - if an invalid `IDE:Version` is specified, the GH action will attempt to download the file, and the contents will contain the xml  from JetBrains' CDN about the resource not existing. When `unzip` tries to unzip this, it will fail, and cause the script to exit early. This change will cause the GitHub action to test the zip files, and if they are invalid show the user a warning message and proceed with the next `IDE:Version` pair.

# Screenshots
## Duplicate IDE detection
### Before
<img width="1316" alt="Screen Shot 2020-12-26 at 01 46 43" src="https://user-images.githubusercontent.com/6374067/103149203-465ba680-471c-11eb-8ddd-6301e36d882e.png">

### After (with the change in this PR)
<img width="523" alt="Screen Shot 2020-12-26 at 01 48 10" src="https://user-images.githubusercontent.com/6374067/103149227-74d98180-471c-11eb-9a51-708d9e965608.png">

#### Example Runs
1. **Normal:** https://github.com/ChrisCarini/sample-intellij-plugin/runs/1610823683?check_suite_focus=true
2. **With Debug Logging:** https://github.com/ChrisCarini/sample-intellij-plugin/runs/1610818444?check_suite_focus=true

## Zip file validation
### Before
<img width="1196" alt="Screen Shot 2020-12-26 at 01 52 50" src="https://user-images.githubusercontent.com/6374067/103149307-224c9500-471d-11eb-94fa-0c6d016b3f97.png">

**Note:** At the time of this execution - 2020-11-03 - 2020.3 had not yet been released, as it was released on 2020-11-20; see below:
<img width="241" alt="Screen Shot 2020-12-26 at 01 54 01" src="https://user-images.githubusercontent.com/6374067/103149330-4dcf7f80-471d-11eb-9ec4-cfab386c5fca.png">

### After (with the change in this PR)
<img width="1171" alt="Screen Shot 2020-12-26 at 02 02 57" src="https://user-images.githubusercontent.com/6374067/103149471-8ae84180-471e-11eb-82d7-12a12d4eab13.png">

#### Example Run
1. **Normal:** https://github.com/ChrisCarini/sample-intellij-plugin/runs/1610860060?check_suite_focus=true