### PR TITLE
#19: Improved logging to help troubleshoot issue where ide-versions was not reading from the file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ file path to a file containing the IDE and versions. Below are the respective ex
 
 **Workflow File:**
 ```yaml
+- uses: actions/checkout@v2 # Your repository must be checked out in order to access the `ide_versions_file.txt` configuration file.
 - name: Verify plugin on IntelliJ Platforms
   id: verify
   uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,6 +139,9 @@ if [[ -f "$GITHUB_WORKSPACE/$INPUT_IDE_VERSIONS" ]]; then
   echo "$INPUT_IDE_VERSIONS" | while read -r INPUT_IDE_VERSION; do
     gh_debug "                   => $INPUT_IDE_VERSION"
   done
+elif [[ $INPUT_IDE_VERSIONS != *":"* ]]; then
+  echo "Did not detect a file at the value given for ide_versions. (If you had specified a file, please make sure you ran the checkout action before running this action). Proceeding to read ide-versions directly from the input..."
+  gh_debug "If ide-versions was given as a file path, the file path should be located at $GITHUB_WORKSPACE/$INPUT_IDE_VERSIONS"
 fi
 
 # Check if there are duplicate entries in the list of IDE_VERSIONS, if so, error out and show the user a clear message


### PR DESCRIPTION
Hi, I raised bug #19 because the action was not reading from the file even when I had specified it. To help debug the issue, I turned on debug logging but it still didn't give me any information why the action was failing to read the file.

After checking out and reading the source code bash script, I finally realized that I would need to checkout my repository for the script to have access to the file. (We have a custom workflow running where we just download the plugin zip file for the compatibility check, rather than checking out the entire repository).

To help future users of this action to quickly debug the issue and not raise new bugs, I have added some logging in the relevant if-condition that will notify the user about whether a file was detected for their `ide-versions` input.


![image](https://user-images.githubusercontent.com/6986426/117573402-9b81ce80-b0a5-11eb-8207-8382b8b3a0a2.png)

closes #19 