### PR TITLE
Adding support for `GITHUB_TOKEN` for authenticated requests to resolve latest release of `JetBrains/intellij-plugin-verifier`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN apk --no-cache add curl
 # We need zip to test the downloaded IDEs
 RUN apk --no-cache add zip
 
+# We may need the gh CLI to run API commands (for more GH API requests per hour)
+RUN wget https://github.com/cli/cli/releases/download/v2.1.0/gh_2.1.0_linux_386.tar.gz -O ghcli.tar.gz && tar --strip-components=1 -xf ghcli.tar.gz
+
 # Copies your code file from the repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A minimal example of a workflow step is below:
 ```yaml
   - name: Verify Plugin on IntelliJ Platforms
     uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
       ide-versions: |
         ideaIC:2019.3
@@ -46,6 +48,8 @@ A minimal example of a workflow step is below:
           - name: Verify Plugin on IntelliJ Platforms
             id: verify
             uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             with:
               ide-versions: |
                 ideaIC:2019.3
@@ -60,6 +64,24 @@ A minimal example of a workflow step is below:
               echo "The verifier log file [${{steps.verify.outputs.verification-output-log-filename}}] contents : " ;
               cat ${{steps.verify.outputs.verification-output-log-filename}}
     ```
+
+### GitHub Token Authentication
+
+In order to
+prevent [GitHub Rate limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting),
+setting the `GITHUB_TOKEN` environment variable is **highly** encouraged.
+
+_**Without**_ the `GITHUB_TOKEN` set, the requests are considered 'unauthenticated requests' by the GitHub API, and are
+subject to 60 requests per hour for the originating IP
+address. [GitHub-hosted runners are hosted in Azure, and have the same IP address ranges as Azure datacenters.](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#ip-addresses)
+As a side effect of this, if the particular IP address of the GitHub-runner executing your GitHub Workflow has made 60
+requests per hour, the API call to resolve the latest version of the `intellij-plugin-verifier` will fail, and this
+action will not complete successfully.
+
+_**With**_ the `GITHUB_TOKEN`
+set, [each repository using this GitHub action will be allowed 1,000 requests per hour](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)
+(which is needed to resolve the latest version of the `intellij-plugin-verifier`). This should be ample for most
+repositories.
 
 ## Options
 
@@ -77,6 +99,8 @@ An example using all the available options is below:
   - name: Verify Plugin on IntelliJ Platforms
     id: verify
     uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
       verifier-version: '1.230'
       plugin-location: 'build/distributions/sample-intellij-plugin-*.zip'
@@ -157,6 +181,8 @@ file path to a file containing the IDE and versions. Below are the respective ex
 - name: Verify plugin on IntelliJ Platforms
   id: verify
   uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
     ide-versions: .github/workflows/ide_versions_file.txt
 ```
@@ -208,6 +234,8 @@ In the below example, we use set the `id` to `verify` - this example will print 
       - name: Verify Plugin on IntelliJ Platforms
         id: verify
         uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           ide-versions: |
             ideaIC:2019.3
@@ -219,7 +247,6 @@ In the below example, we use set the `id` to `verify` - this example will print 
 ```
 
 (**Note:** The file contents will include both `stdout` and `stderr` output from the plugin verification CLI.)
-
 
 # Examples
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -164,7 +164,14 @@ fi
 if [[ "$INPUT_VERIFIER_VERSION" == "LATEST" ]]; then
     gh_debug "LATEST verifier version found, resolving version..."
     GH_LATEST_RELEASE_FILE="$HOME/intellij-plugin-verifier_latest_gh_release.json"
-    curl --silent --show-error https://api.github.com/repos/JetBrains/intellij-plugin-verifier/releases/latest > "$GH_LATEST_RELEASE_FILE"
+    gh_debug "IS GITHUB_TOKEN SET? -> $( [[ -z "${GITHUB_TOKEN-}" ]] && echo "NO" || echo "YES" )"
+    if [[ -z "${GITHUB_TOKEN+x}" ]] ; then
+        curl --silent --show-error https://api.github.com/repos/JetBrains/intellij-plugin-verifier/releases/latest > "$GH_LATEST_RELEASE_FILE"
+        curl https://api.github.com/rate_limit | gh_debug
+    else
+        gh api repos/JetBrains/intellij-plugin-verifier/releases/latest > "$GH_LATEST_RELEASE_FILE"
+        gh api rate_limit | gh_debug
+    fi
     VERIFIER_VERSION=$(cat "$GH_LATEST_RELEASE_FILE" | jq -r .tag_name | sed 's/[^[:digit:].]*//g')
     VERIFIER_JAR_FILENAME=$(cat "$GH_LATEST_RELEASE_FILE" | jq -r .assets[].name)
     VERIFIER_DOWNLOAD_URL=$(cat "$GH_LATEST_RELEASE_FILE" | jq -r .assets[].browser_download_url)


### PR DESCRIPTION
Adding support for `GITHUB_TOKEN` for authenticated requests to resolve latest release of `JetBrains/intellij-plugin-verifier`.

Fixes #25