### PR TITLE
#76 Adds support for mute args

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,18 @@ This required input sets which plugin verifier failures to cause a failure in th
 the two default checks as of authoring this capability. This may change in the future, but a minor version bump (at a
 minimum) will happen should that occur.
 
+### `mute-plugin-problems`
+
+This optional input sets which plugins problems will be ignored. Multiple values can be passed in as a comma-separated string.
+
+See https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin for more details.
+
+#### Valid options
+
+    - `ForbiddenPluginIdPrefix`
+    - `TemplateWordInPluginId`
+    - `TemplateWordInPluginName`
+
 ## Results
 The results of the execution are captured in a file for use in subsequent steps if you so choose.
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
     #   were the two default checks as of authoring this input feature. This may change in the future,
     #   but a minor version bump (at a minimum) will happen if/when that occurs.
     default: 'COMPATIBILITY_PROBLEMS INVALID_PLUGIN'
+  mute-plugin-problems:
+    description: 'The comma-separated list of rules to suppress. See https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#specific-options for a list of valid values.'
+    required: false
 outputs:
   verification-output-log-filename:
     description: The filename of the log file generated from the verification output. The output file contains both `stdout` and `stderr` streams.
@@ -42,3 +45,4 @@ runs:
     - ${{ inputs.plugin-location }}
     - ${{ inputs.ide-versions }}
     - ${{ inputs.failure-levels }}
+    - ${{ inputs.mute-plugin-problems }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -122,7 +122,7 @@ FAILURE_LEVELS="$4"
 #
 # Input string can be a comma separated list
 #
-# mute-plugin-problems: ['ForbiddenPluginIdPrefix', 'TemplateWordInPluginId', 'TemplateWordInPluginName']
+# mute-plugin-problems: 'ForbiddenPluginIdPrefix,TemplateWordInPluginId,TemplateWordInPluginName'
 INPUT_MUTE_PLUGIN_PROBLEMS="$5"
 
 # the content-type headers returned by the platform download calls


### PR DESCRIPTION
Hi @ChrisCarini, this is my first attempt at it. 

For now, the input expects a comma-separated list of items, same as the CLI tool. I noticed that some of the options accept newlines or files as inputs, do you want to copy that pattern here instead? I didn't think there would be too much gained by following that pattern in this case since it's a small set of possible values. Thoughts?

ref: #76